### PR TITLE
Update .d.ts file to fix Top-level declarations error (TS1046)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-class _SubRange {
+declare class _SubRange {
   constructor(low: number, high: number);
 
   low: number;
@@ -18,7 +18,7 @@ class _SubRange {
   clone(): _SubRange;
 }
 
-export = class DiscontinuousRange {
+declare class DiscontinuousRange {
   constructor();
   constructor(i: number);
   constructor(start: number, end: number);
@@ -44,3 +44,5 @@ export = class DiscontinuousRange {
 
   clone(): DiscontinuousRange;
 }
+
+export = DiscontinuousRange;


### PR DESCRIPTION
# The problem
Since typescript 0.9 

> Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.


see: https://typescript.tv/errors/ts1046/

# How to test it:
- run `npx -p typescript tsc index.d.ts --noEmit` on the current master and it will fail.
- run `npx -p typescript tsc index.d.ts --noEmit` on this PR and it will succeed.